### PR TITLE
Verbose request failed error

### DIFF
--- a/lib/messagebird.js
+++ b/lib/messagebird.js
@@ -92,7 +92,7 @@ module.exports = function (accessKey, timeout) {
 
     // process client error
     request.on('error', function (e) {
-      var error = new Error('request failed');
+      var error = new Error('request failed: ' + e.message);
 
       if (error.message === 'ECONNRESET') {
         error = new Error('request timeout');
@@ -137,6 +137,7 @@ module.exports = function (accessKey, timeout) {
           }
         } catch (e) {
           error = new Error('response failed');
+
           error.statusCode = response.statusCode;
           error.error = e;
           data = null;

--- a/lib/messagebird.js
+++ b/lib/messagebird.js
@@ -137,7 +137,6 @@ module.exports = function (accessKey, timeout) {
           }
         } catch (e) {
           error = new Error('response failed');
-
           error.statusCode = response.statusCode;
           error.error = e;
           data = null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messagebird",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A node.js wrapper for the MessageBird REST API",
   "main": "lib/messagebird.js",
   "engines": {


### PR DESCRIPTION
This PR ensures a more verbose error for failed HTTP requests. The wrapped error was already available in `e.error`, but having the original error message suffixed is useful for error reporting services/utilities.