### PR TITLE
Ensure requiring package.json works when bundling module

### DIFF
--- a/lib/messagebird.js
+++ b/lib/messagebird.js
@@ -6,9 +6,7 @@
 
 var http = require('https');
 var querystring = require('querystring');
-var ospath = require('path');
-var root = ospath.resolve('.');
-var pkg = require(root + '/package.json');
+var pkg = require('../package.json');
 
 /**
  * module.exports sets configuration

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messagebird",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "A node.js wrapper for the MessageBird REST API",
   "main": "lib/messagebird.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messagebird",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A node.js wrapper for the MessageBird REST API",
   "main": "lib/messagebird.js",
   "engines": {


### PR DESCRIPTION
Currently, bundling the messagebird module causes an issue because the package.json file referenced in the library doesn't get bundled. This PR ensures it does.