### PR TITLE
Increase error message verbosity for API client errors

### DIFF
--- a/lib/messagebird.js
+++ b/lib/messagebird.js
@@ -128,7 +128,10 @@ module.exports = function (accessKey, timeout) {
         try {
           data = JSON.parse(data);
           if (data.errors) {
-            error = new Error('api error');
+            var clientErrors = data.errors.map(function (e) {
+              return e.description + ' (code: ' + e.code + (e.parameter ? ', parameter: ' + e.parameter : '') + ')';
+            });
+            error = new Error('api error(s): ' + clientErrors.join(', '));
             error.statusCode = response.statusCode;
             error.errors = data.errors;
             data = null;

--- a/lib/test.js
+++ b/lib/test.js
@@ -172,7 +172,7 @@ queue.push(function () {
     function (err) {
       doTest(null, 'error handling', [
         ['type', err instanceof Error],
-        ['message', err.message === 'api error'],
+        ['message', err.message === 'api error(s): no (correct) recipients found (code: 9, parameter: recipients), originator is required (code: 9, parameter: originator)'],
         ['errors', err.errors instanceof Array]
       ]);
     }
@@ -209,7 +209,7 @@ queue.push(function () {
       if (accessType === 'TEST') {
         doTest(null, 'messages.read', [
           ['type', err instanceof Error],
-          ['.message', err.message === 'api error'],
+          ['.message', err.message === 'api error(s): message not found (code: 20)'],
           ['.errors', err.errors instanceof Array]
         ]);
       } else {
@@ -240,7 +240,7 @@ queue.push(function () {
       if (accessType === 'TEST') {
         doTest(null, 'voice_messages.read', [
           ['type', err instanceof Error],
-          ['.message', err.message === 'api error'],
+          ['.message', err.message === 'api error(s): message not found (code: 20)'],
           ['.errors', err.errors instanceof Array]
         ]);
       } else {
@@ -275,7 +275,7 @@ queue.push(function () {
       if (accessType === 'TEST') {
         doTest(null, 'hlr.read', [
           ['type', err instanceof Error],
-          ['.message', err.message === 'api error'],
+          ['.message', err.message === 'api error(s): hlr not found (code: 20)'],
           ['.errors', err.errors instanceof Array]
         ]);
       } else {
@@ -352,7 +352,7 @@ queue.push(function () {
       if (accessType === 'TEST' && err) {
         doTest(null, 'hlr.read', [
           ['type', err instanceof Error],
-          ['.message', err.message === 'api error'],
+          ['.message', err.message === 'api error(s): Not found (hlr not found) (code: 20)'],
           ['.errors', err.errors instanceof Array]
         ]);
       } else {


### PR DESCRIPTION
When API responds with a `400 Bad Request` (validation errors, insufficient balance, etc.), instead of having `api error` as the Error message, append the actual errors. See updated tests for example error messages. Note: the `errors` array returned by the API is still available in the `errors` key of the Error object.

Example:

Before:
```api error```

After:
```api error(s): no (correct) recipients found (code: 9, parameter: recipients), originator is required (code: 9, parameter: originator)```