### PR TITLE
URL-encode phone numbers so Lookup API can handle formats with spaces

### DIFF
--- a/lib/messagebird.js
+++ b/lib/messagebird.js
@@ -350,7 +350,7 @@ module.exports = function (accessKey, timeout) {
           params.countryCode = countryCode;
         }
 
-        httpRequest('GET', '/lookup/' + phoneNumber, params, callback);
+        httpRequest('GET', '/lookup/' + encodeURIComponent(phoneNumber), params, callback);
       },
 
       hlr: {
@@ -375,7 +375,7 @@ module.exports = function (accessKey, timeout) {
             params.countryCode = countryCode;
           }
 
-          httpRequest('GET', '/lookup/' + phoneNumber + '/hlr', params, callback);
+          httpRequest('GET', '/lookup/' + encodeURIComponent(phoneNumber) + '/hlr', params, callback);
         },
 
         /**
@@ -392,7 +392,7 @@ module.exports = function (accessKey, timeout) {
             params = null;
           }
 
-          httpRequest('POST', '/lookup/' + phoneNumber + '/hlr', params, callback);
+          httpRequest('POST', '/lookup/' + encodeURIComponent(phoneNumber) + '/hlr', params, callback);
         }
       }
     }


### PR DESCRIPTION
The Lookup API can be used to parse and normalize phone numbers but it fails (with `TypeError [ERR_UNESCAPED_CHARACTERS]: Request path contains unescaped characters`) when the number contains spaces. Developers would have to URL-encode numbers, which is against the principle that an SDK should abstract HTTP details. This PR fixes that by URL-encoding within the SDK.