### PR TITLE
Add contacts and groups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
 node_js:
+  - "10"
+  - "9"
+  - "8"
   - "7"
   - "6"
   - "5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ node_js:
   - "iojs"
 env:
   - MB_ACCESSKEY="test_iQpAp0KCs5GCsMpDhIx2leuNB"
+matrix:
+  allow_failures:
+    - node_js: iojs

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,5 @@ env:
   - MB_ACCESSKEY="test_iQpAp0KCs5GCsMpDhIx2leuNB"
 matrix:
   allow_failures:
-    - node_js: iojs
+    - node_js: "0.8"
+    - node_js: "iojs"

--- a/lib/messagebird.js
+++ b/lib/messagebird.js
@@ -70,7 +70,7 @@ module.exports = function (accessKey, timeout) {
       }
     };
 
-    if (options.method === 'POST' || options.method === 'PUT') {
+    if (options.method === 'POST' || options.method === 'PUT' || options.method === 'PATCH') {
       body = JSON.stringify(params);
       options.headers['Content-Type'] = 'application/json';
       options.headers['Content-Length'] = Buffer.byteLength(body, 'utf8');
@@ -395,6 +395,97 @@ module.exports = function (accessKey, timeout) {
           httpRequest('POST', '/lookup/' + phoneNumber + '/hlr', params, callback);
         }
       }
+    },
+
+    contacts: {
+
+      /**
+       * Create a new contact. Params is optional.
+       *
+       * @param {String} phoneNumber
+       * @param {Object} params
+       * @param {Function} callback
+       * @return void
+       */
+      create: function (phoneNumber, params, callback) {
+        if (typeof params === 'function') {
+          callback = params;
+          params = {};
+        }
+
+        params.msisdn = phoneNumber;
+
+        httpRequest('POST', '/contacts', params, callback);
+      },
+
+      /**
+       * View an existing contact.
+       *
+       * @param {String} id
+       * @param {Function} callback
+       * @return void
+       */
+      read: function (id, callback) {
+        httpRequest('GET', '/contacts/' + id, callback);
+      },
+
+      /**
+       * Updates an existing contact. Params is optional.
+       *
+       * @param {String} id
+       * @param {String} name
+       * @param {Object} params
+       * @param {Function} callback
+       * @return void
+       */
+      update: function (id, name, params, callback) {
+        if (typeof params === 'function') {
+          callback = params;
+          params = {};
+        }
+
+        params.name = name;
+
+        httpRequest('PATCH', '/contacts/' + id, params, callback);
+      },
+
+      /**
+       * Deletes an existing contact. The callback is invoked with an error if
+       * applicable, but the data will never contain anything meaningful as the
+       * API returns an empty response for successful deletes.
+       *
+       * @param {String} id
+       * @param {Function} callback
+       * @return void
+       */
+      delete: function (id, callback) {
+        httpRequest('DELETE', '/contacts/' + id, callback);
+      },
+
+      /**
+       * Lists existing contacts. Pagination is optional. If a limit is set, an
+       * offset is also required.
+       *
+       * @param {Number} limit
+       * @param {Number} offset
+       * @param {Function} callback
+       * @return void
+       */
+      list: function (limit, offset, callback) {
+        var params = null;
+
+        if (typeof callback === 'function') {
+          params = {
+            limit: limit,
+            offset: offset
+          };
+        } else {
+          callback = limit;
+        }
+
+        httpRequest('GET', '/contacts', params, callback);
+      }
+
     }
   };
 };

--- a/lib/messagebird.js
+++ b/lib/messagebird.js
@@ -475,13 +475,11 @@ module.exports = function (accessKey, timeout) {
        * @param {Function} callback
        * @return void
        */
-      update: function (id, name, params, callback) {
+      update: function (id, params, callback) {
         if (typeof params === 'function') {
           callback = params;
           params = {};
         }
-
-        params.name = name;
 
         httpRequest('PATCH', '/contacts/' + id, params, callback);
       },

--- a/lib/messagebird.js
+++ b/lib/messagebird.js
@@ -490,6 +490,14 @@ module.exports = function (accessKey, timeout) {
 
     groups: {
 
+      /**
+       * Creates a new group. Params is optional.
+       *
+       * @param {String} name
+       * @param {Object} params
+       * @param {Function} callback
+       * @return void
+       */
       create: function (name, params, callback) {
         if (typeof params === 'function') {
           callback = params;
@@ -501,10 +509,28 @@ module.exports = function (accessKey, timeout) {
         httpRequest('POST', '/groups', params, callback);
       },
 
+      /**
+       * Deletes an existing group. The callback is invoked with an error if
+       * applicable, but the data will never contain anything meaningful as the
+       * API returns an empty response for successful deletes.
+       *
+       * @param {String} id
+       * @param {Function} callback
+       * @return void
+       */
       delete: function (id, callback) {
         httpRequest('DELETE', '/groups/' + id, callback);
       },
 
+      /**
+       * Lists existing groups. Pagination is optional. If a limit is set, an
+       * offset is also required.
+       *
+       * @param {Number} limit
+       * @param {Number} offset
+       * @param {Function} callback
+       * @return void
+       */
       list: function (limit, offset, callback) {
         var params = null;
 
@@ -520,10 +546,26 @@ module.exports = function (accessKey, timeout) {
         httpRequest('GET', '/groups', params, callback);
       },
 
+      /**
+       * View an existing group.
+       *
+       * @param {String} id
+       * @param {Function} callback
+       * @return void
+       */
       read: function (id, callback) {
         httpRequest('GET', '/groups/' + id, callback);
       },
 
+      /**
+       * Updates an existing contact. Parmas is optional.
+       *
+       * @param {String} id
+       * @param {String} name
+       * @param {Object} params
+       * @param {Function} callback
+       * @return void
+       */
       update: function (id, name, params, callback) {
         if (typeof params === 'function') {
           callback = params;
@@ -535,6 +577,14 @@ module.exports = function (accessKey, timeout) {
         httpRequest('PATCH', '/groups/' + id, params, callback);
       },
 
+      /**
+       * Adds anywhere from 1 to 50 contacts to a group.
+       *
+       * @param {String} groupId
+       * @param {String[]} contactIds
+       * @param {Function} callback
+       * @return void
+       */
       addContacts: function (groupId, contactIds, callback) {
         // We need to make a PUT request with a body formatted like:
         // `ids[]=contact-id&ids[]=other-contact-id`. The httpRequest method
@@ -564,6 +614,14 @@ module.exports = function (accessKey, timeout) {
         return params.join('&');
       },
 
+      /**
+       * Removes a single contact from a group.
+       *
+       * @param {String} groupId
+       * @param {String} contactId
+       * @param {Function} callback
+       * @return void
+       */
       removeContact: function (groupId, contactId, callback) {
         httpRequest('DELETE', '/groups/' + groupId + '/contacts/' + contactId, callback);
       }

--- a/lib/messagebird.js
+++ b/lib/messagebird.js
@@ -408,6 +408,11 @@ module.exports = function (accessKey, timeout) {
        * @return void
        */
       create: function (phoneNumber, params, callback) {
+        if (typeof params === 'function') {
+          callback = params;
+          params = {};
+        }
+
         params.msisdn = phoneNumber;
 
         httpRequest('POST', '/contacts', params, callback);
@@ -535,6 +540,11 @@ module.exports = function (accessKey, timeout) {
        * @return void
        */
       create: function (name, params, callback) {
+        if (typeof params === 'function') {
+          callback = params;
+          params = {};
+        }
+
         params.name = name;
 
         httpRequest('POST', '/groups', params, callback);
@@ -598,6 +608,11 @@ module.exports = function (accessKey, timeout) {
        * @return void
        */
       update: function (id, name, params, callback) {
+        if (typeof params === 'function') {
+          callback = params;
+          params = {};
+        }
+
         params.name = name;
 
         httpRequest('PATCH', '/groups/' + id, params, callback);

--- a/lib/messagebird.js
+++ b/lib/messagebird.js
@@ -419,37 +419,6 @@ module.exports = function (accessKey, timeout) {
       },
 
       /**
-       * View an existing contact.
-       *
-       * @param {String} id
-       * @param {Function} callback
-       * @return void
-       */
-      read: function (id, callback) {
-        httpRequest('GET', '/contacts/' + id, callback);
-      },
-
-      /**
-       * Updates an existing contact. Params is optional.
-       *
-       * @param {String} id
-       * @param {String} name
-       * @param {Object} params
-       * @param {Function} callback
-       * @return void
-       */
-      update: function (id, name, params, callback) {
-        if (typeof params === 'function') {
-          callback = params;
-          params = {};
-        }
-
-        params.name = name;
-
-        httpRequest('PATCH', '/contacts/' + id, params, callback);
-      },
-
-      /**
        * Deletes an existing contact. The callback is invoked with an error if
        * applicable, but the data will never contain anything meaningful as the
        * API returns an empty response for successful deletes.
@@ -484,6 +453,37 @@ module.exports = function (accessKey, timeout) {
         }
 
         httpRequest('GET', '/contacts', params, callback);
+      },
+
+      /**
+       * View an existing contact.
+       *
+       * @param {String} id
+       * @param {Function} callback
+       * @return void
+       */
+      read: function (id, callback) {
+        httpRequest('GET', '/contacts/' + id, callback);
+      },
+
+      /**
+       * Updates an existing contact. Params is optional.
+       *
+       * @param {String} id
+       * @param {String} name
+       * @param {Object} params
+       * @param {Function} callback
+       * @return void
+       */
+      update: function (id, name, params, callback) {
+        if (typeof params === 'function') {
+          callback = params;
+          params = {};
+        }
+
+        params.name = name;
+
+        httpRequest('PATCH', '/contacts/' + id, params, callback);
       }
 
     }

--- a/lib/messagebird.js
+++ b/lib/messagebird.js
@@ -484,6 +484,54 @@ module.exports = function (accessKey, timeout) {
         params.name = name;
 
         httpRequest('PATCH', '/contacts/' + id, params, callback);
+      },
+
+      /**
+       * Lists the groups a contact is part of.
+       *
+       * @param {String} contactId
+       * @param {Number} limit
+       * @param {Number} offset
+       * @param {Function} callback
+       * @return void
+       */
+      listGroups: function (contactId, limit, offset, callback) {
+        var params = null;
+
+        if (typeof callback === 'function') {
+          params = {
+            limit: limit,
+            offset: offset
+          };
+        } else {
+          callback = limit;
+        }
+
+        httpRequest('GET', '/contacts/' + contactId + '/groups', params, callback);
+      },
+
+      /**
+       * Lists the messages for a contact.
+       *
+       * @param {String} contactId
+       * @param {Number} limit
+       * @param {Number} offset
+       * @param {Function} callback
+       * @return void
+       */
+      listMessages: function (contactId, limit, offset, callback) {
+        var params = null;
+
+        if (typeof callback === 'function') {
+          params = {
+            limit: limit,
+            offset: offset
+          };
+        } else {
+          callback = limit;
+        }
+
+        httpRequest('GET', '/contacts/' + contactId + '/messages', params, callback);
       }
 
     },
@@ -612,6 +660,30 @@ module.exports = function (accessKey, timeout) {
         }
         
         return params.join('&');
+      },
+
+      /**
+       * Lists the contacts that are part of a group.
+       *
+       * @param {String} groupId
+       * @param {Number} limit
+       * @param {Number} offset
+       * @param {Function} callback
+       * @return void
+       */
+      listContacts: function (groupId, limit, offset, callback) {
+        var params = null;
+
+        if (typeof callback === 'function') {
+          params = {
+            limit: limit,
+            offset: offset
+          };
+        } else {
+          callback = limit;
+        }
+
+        httpRequest('GET', '/groups/' + groupId + '/contacts', params, callback);
       },
 
       /**

--- a/lib/messagebird.js
+++ b/lib/messagebird.js
@@ -408,11 +408,6 @@ module.exports = function (accessKey, timeout) {
        * @return void
        */
       create: function (phoneNumber, params, callback) {
-        if (typeof params === 'function') {
-          callback = params;
-          params = {};
-        }
-
         params.msisdn = phoneNumber;
 
         httpRequest('POST', '/contacts', params, callback);
@@ -476,11 +471,6 @@ module.exports = function (accessKey, timeout) {
        * @return void
        */
       update: function (id, params, callback) {
-        if (typeof params === 'function') {
-          callback = params;
-          params = {};
-        }
-
         httpRequest('PATCH', '/contacts/' + id, params, callback);
       },
 
@@ -545,11 +535,6 @@ module.exports = function (accessKey, timeout) {
        * @return void
        */
       create: function (name, params, callback) {
-        if (typeof params === 'function') {
-          callback = params;
-          params = {};
-        }
-
         params.name = name;
 
         httpRequest('POST', '/groups', params, callback);
@@ -613,11 +598,6 @@ module.exports = function (accessKey, timeout) {
        * @return void
        */
       update: function (id, name, params, callback) {
-        if (typeof params === 'function') {
-          callback = params;
-          params = {};
-        }
-
         params.name = name;
 
         httpRequest('PATCH', '/groups/' + id, params, callback);

--- a/lib/messagebird.js
+++ b/lib/messagebird.js
@@ -120,7 +120,7 @@ module.exports = function (accessKey, timeout) {
           .toString()
           .trim();
 
-        if (method === 'DELETE' && response.statusCode === 204) {
+        if (response.statusCode === 204) {
           doCallback(null, true);
           return;
         }
@@ -486,6 +486,89 @@ module.exports = function (accessKey, timeout) {
         httpRequest('PATCH', '/contacts/' + id, params, callback);
       }
 
+    },
+
+    groups: {
+
+      create: function (name, params, callback) {
+        if (typeof params === 'function') {
+          callback = params;
+          params = {};
+        }
+
+        params.name = name;
+
+        httpRequest('POST', '/groups', params, callback);
+      },
+
+      delete: function (id, callback) {
+        httpRequest('DELETE', '/groups/' + id, callback);
+      },
+
+      list: function (limit, offset, callback) {
+        var params = null;
+
+        if (typeof callback === 'function') {
+          params = {
+            limit: limit,
+            offset: offset
+          };
+        } else {
+          callback = limit;
+        }
+
+        httpRequest('GET', '/groups', params, callback);
+      },
+
+      read: function (id, callback) {
+        httpRequest('GET', '/groups/' + id, callback);
+      },
+
+      update: function (id, name, params, callback) {
+        if (typeof params === 'function') {
+          callback = params;
+          params = {};
+        }
+
+        params.name = name;
+
+        httpRequest('PATCH', '/groups/' + id, params, callback);
+      },
+
+      addContacts: function (groupId, contactIds, callback) {
+        // We need to make a PUT request with a body formatted like:
+        // `ids[]=contact-id&ids[]=other-contact-id`. The httpRequest method
+        // encodes all request bodies to JSON though.
+        //
+        // Instead, we'll send a GET request and pass a _method=PUT parameter
+        // that will ask the API to handle our request as a PUT. We can then
+        // provide the contact IDs in the query string.
+        var query = this.getAddContactsQueryString(contactIds);
+
+        httpRequest('GET', '/groups/' + groupId + '?' + query, null, callback);
+      },
+
+      getAddContactsQueryString: function (contactIds) {
+        // Map the contact IDs to the
+        // `_method=PUT&ids[]=contact-id&ids[]=other-contact-id` format. See
+        // docs in addContacts and:
+        // * https://developers.messagebird.com/docs/alternatives
+        // * https://developers.messagebird.com/docs/groups#add-contact-to-group
+        var params = [];
+        
+        params.push('_method=PUT');
+        for (var i = 0; i < contactIds.length; i++) {
+          params.push('ids[]=' + contactIds[i]);
+        }
+        
+        return params.join('&');
+      },
+
+      removeContact: function (groupId, contactId, callback) {
+        httpRequest('DELETE', '/groups/' + groupId + '/contacts/' + contactId, callback);
+      }
+
     }
+
   };
 };

--- a/lib/test.js
+++ b/lib/test.js
@@ -492,7 +492,7 @@ queue.push(function () {
     });
 
   messagebird.contacts.delete('non-existing', function (err) {
-    expectError(err, 'contacts.delete');
+    expectError(err, 'contacts.delete.witherror');
   });
 });
 
@@ -582,6 +582,187 @@ queue.push(function () {
 
   messagebird.contacts.list(function (err, data) {
     doTest(err, 'contacts.list.withoutpagination', []);
+  });
+});
+
+queue.push(function () {
+  nock('https://rest.messagebird.com')
+    .post('/groups', '{"name":"friends"}')
+    .reply(200, {});
+
+  messagebird.groups.create('friends', function (err, data) {
+    doTest(err, 'groups.create', []);
+  });
+});
+
+queue.push(function () {
+  nock('https://rest.messagebird.com')
+    .delete('/groups/group-id')
+    .reply(204, '');
+
+  messagebird.groups.delete('group-id', function (err) {
+    doTest(err, 'groups.delete', []);
+  });
+});
+
+queue.push(function () {
+  nock('https://rest.messagebird.com')
+    .get('/groups')
+    .query({
+      limit: 10,
+      offset: 20
+    })
+    .reply(200, {});
+
+  messagebird.groups.list(10, 20, function (err, data) {
+    doTest(err, 'groups.list', []);
+  });
+});
+
+queue.push(function () {
+  nock('https://rest.messagebird.com')
+    .get('/groups')
+    .reply(200, {
+      offset: 0,
+      limit: 10,
+      count: 2,
+      totalCount: 2,
+      links: {
+        first: 'https://rest.messagebird.com/groups?offset=0&limit=10',
+        previous: null,
+        next: null,
+        last: 'https://rest.messagebird.com/groups?offset=0&limit=10'
+      },
+      items: [
+        {
+          id: 'first-id',
+          href: 'https://rest.messagebird.com/groups/first-id',
+          name: 'First',
+          contacts: {
+            totalCount: 3,
+            href: 'https://rest.messagebird.com/groups/first-id/contacts'
+          },
+          createdDatetime: '2018-07-25T11:47:42+00:00',
+          updatedDatetime: '2018-07-25T14:03:09+00:00'
+        },
+        {
+          id: 'second-id',
+          href: 'https://rest.messagebird.com/groups/second-id',
+          name: 'Second',
+          contacts: {
+            totalCount: 4,
+            href: 'https://rest.messagebird.com/groups/second-id/contacts'
+          },
+          createdDatetime: '2018-07-25T11:47:39+00:00',
+          updatedDatetime: '2018-07-25T14:03:09+00:00'
+        }
+      ]
+    }
+    );
+
+  messagebird.groups.list(function (err, data) {
+    doTest(err, 'groups.list.withoutpagination', [
+      ['.links.last', data.links.last === 'https://rest.messagebird.com/groups?offset=0&limit=10'],
+      ['.items[0].name', data.items[0].name === 'First'],
+      ['.items[1].contacts.totalCount', data.items[1].contacts.totalCount === 4]
+    ]);
+  });
+});
+
+queue.push(function () {
+  nock('https://rest.messagebird.com')
+    .get('/groups/group-id')
+    .reply(200, {
+      id: 'group-id',
+      href: 'https://rest.messagebird.com/groups/group-id',
+      name: 'Friends',
+      contacts: {
+        totalCount: 3,
+        href: 'https://rest.messagebird.com/groups/group-id'
+      },
+      createdDatetime: '2018-07-25T12:16:10+00:00',
+      updatedDatetime: '2018-07-25T12:16:23+00:00'
+    }
+    );
+
+  messagebird.groups.read('group-id', function (err, data) {
+    doTest(err, 'groups.read', [
+      ['.id', data.id === 'group-id'],
+      ['.contacts.href', data.contacts.href === 'https://rest.messagebird.com/groups/group-id']
+    ]);
+  });
+});
+
+queue.push(function () {
+  nock('https://rest.messagebird.com')
+    .patch('/groups/group-id', '{"name":"new-name"}')
+    .reply(200, {
+      id: 'group-id',
+      href: 'https://rest.messagebird.com/groups/group-id',
+      name: 'new-name',
+      contacts: {
+        totalCount: 3,
+        href: 'https://rest.messagebird.com/groups/group-id'
+      },
+      createdDatetime: '2018-07-25T12:16:10+00:00',
+      updatedDatetime: '2018-07-25T12:16:23+00:00'
+    }
+    );
+
+  messagebird.groups.update('group-id', 'new-name', function (err, data) {
+    doTest(err, 'groups.update', [
+      ['.id', data.id === 'group-id']
+    ]);
+  });
+});
+
+queue.push(function () {
+  nock('https://rest.messagebird.com')
+    .get('/groups/group-id')
+    .query(function (queryString) {
+      // nock isn't too forgiving when it comes to non-standard queries. The
+      // closest we can get to properly testing the query is comparing the
+      // encoded JSON. The query is, in fact, `_method=PUT&ids[]=first-id&ids[]=second-id`.
+      var expected = '{"_method":"PUT","ids":["first-id","second-id"]}';
+
+      return JSON.stringify(queryString) === expected;
+    })
+    .reply(204, '');
+
+  messagebird.groups.addContacts('group-id', ['first-id', 'second-id'], function (err) {
+    doTest(err, 'groups.addContacts', []);
+  });
+});
+
+queue.push(function () {
+  var matchAnyQuery = true;
+
+  nock('https://rest.messagebird.com')
+    .get('/groups/group-id')
+    .query(matchAnyQuery)
+    .reply(404, {
+      errors: [
+        {
+          code: 20,
+          description: 'contact not found',
+          parameter: null
+        }
+      ]
+    }
+    );
+
+  messagebird.groups.addContacts('group-id', ['first-id', 'second-id'], function (err) {
+    expectError(err, 'groups.addContects.witherror');
+  });
+});
+
+queue.push(function () {
+  nock('https://rest.messagebird.com')
+    .delete('/groups/group-id/contacts/contact-id')
+    .reply(204, '');
+
+  messagebird.groups.removeContact('group-id', 'contact-id', function (err) {
+    doTest(err, 'groups.removeContact', []);
   });
 });
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -1,6 +1,7 @@
 var fs = require('fs');
 var path = require ('path');
 var root = path.resolve('.');
+var nock = require('nock');
 var pkg = require(root + '/package.json');
 var MessageBird = require(root);
 var messagebird;
@@ -163,6 +164,18 @@ function doTest(err, label, tests) {
   }
 
   doNext();
+}
+
+/**
+ * expectError fails if the error is empty.
+ *
+ * @param {Error} err
+ * @param {String} label
+ */
+function expectError(err, label) {
+  doTest(null, label, [
+    ['expectError', err instanceof Error]
+  ]);
 }
 
 
@@ -366,6 +379,210 @@ queue.push(function () {
       }
     });
   }, 500);
+});
+
+queue.push(function () {
+  var params = {
+    'msisdn': 31612345678,
+    'firstName': 'Foo',
+    'custom3': 'Third'
+  };
+
+  nock('https://rest.messagebird.com')
+    .post('/contacts', '{"msisdn":31612345678,"firstName":"Foo","custom3":"Third"}')
+    .reply(200, {
+      id: 'contact-id',
+      href: 'https://rest.messagebird.com/contacts/contact-id',
+      msisdn: 31612345678,
+      firstName: 'Foo',
+      lastName: 'Bar',
+      customDetails: {
+        custom1: 'First',
+        custom2: 'Second',
+        custom3: 'Third',
+        custom4: 'Fourth'
+      },
+      groups: {
+        totalCount: 3,
+        href: 'https://rest.messagebird.com/contacts/contact-id/groups'
+      },
+      messages: {
+        totalCount: 5,
+        href: 'https://rest.messagebird.com/contacts/contact-id/messages'
+      },
+      createdDatetime: '2018-07-13T10:34:08+00:00',
+      updatedDatetime: '2018-07-13T10:44:08+00:00'
+    });
+
+  messagebird.contacts.create(31612345678, params, function (err, data) {
+    doTest(err, 'contacts.create', [
+      ['.msisdn', data.msisdn === 31612345678],
+      ['.customDetails.custom3', data.customDetails.custom3 === 'Third'],
+      ['.groups.totalCount', data.groups.totalCount === 3]
+    ]);
+  });
+});
+
+queue.push(function () {
+  nock('https://rest.messagebird.com')
+    .get('/contacts/contact-id')
+    .reply(200, {
+      id: 'contact-id',
+      href: 'https://rest.messagebird.com/contacts/contact-id',
+      msisdn: 31612345678,
+      firstName: 'Foo',
+      lastName: 'Bar',
+      customDetails: {
+        custom1: 'First',
+        custom2: 'Second',
+        custom3: 'Third',
+        custom4: 'Fourth'
+      },
+      groups: {
+        totalCount: 3,
+        href: 'https://rest.messagebird.com/contacts/contact-id/groups'
+      },
+      messages: {
+        totalCount: 5,
+        href: 'https://rest.messagebird.com/contacts/contact-id/messages'
+      },
+      createdDatetime: '2018-07-13T10:34:08+00:00',
+      updatedDatetime: '2018-07-13T10:44:08+00:00'
+    });
+
+  messagebird.contacts.read('contact-id', function (err, data) {
+    doTest(err, 'contacts.read', [
+      ['.id', data.id === 'contact-id'],
+      ['.firstName', data.firstName === 'Foo']
+    ]);
+  });
+});
+
+queue.push(function () {
+  nock('https://rest.messagebird.com')
+    .patch('/contacts/contact-id', '{"name":"new-name"}')
+    .reply(200, {});
+
+  messagebird.contacts.update('contact-id', 'new-name', function (err, data) {
+    doTest(err, 'contacts.update', []);
+  });
+});
+
+queue.push(function () {
+  nock('https://rest.messagebird.com')
+    .delete('/contacts/contact-id')
+    .reply(204, '');
+
+  messagebird.contacts.delete('contact-id', function (err) {
+    doTest(err, 'contacts.delete', []);
+  });
+});
+
+queue.push(function () {
+  nock('https://rest.messagebird.com')
+    .delete('/contacts/non-existing')
+    .reply(404, {
+      errors: [
+        {
+          code: 20,
+          description: 'contact not found',
+          parameter: null
+        }
+      ]
+    });
+
+  messagebird.contacts.delete('non-existing', function (err) {
+    expectError(err, 'contacts.delete');
+  });
+});
+
+queue.push(function () {
+  nock('https://rest.messagebird.com')
+    .get('/contacts')
+    .query({
+      limit: 10,
+      offset: 20
+    })
+    .reply(200, {
+      offset: 20,
+      limit: 10,
+      count: 2,
+      totalCount: 22,
+      links: {
+        first: 'https://rest.messagebird.com/contacts?offset=0',
+        previous: null,
+        next: null,
+        last: 'https://rest.messagebird.com/contacts?offset=0'
+      },
+      items: [
+        {
+          id: 'first-id',
+          href: 'https://rest.messagebird.com/contacts/first-id',
+          msisdn: 31612345678,
+          firstName: 'Foo',
+          lastName: 'Bar',
+          customDetails: {
+            custom1: null,
+            custom2: null,
+            custom3: null,
+            custom4: null
+          },
+          groups: {
+            totalCount: 0,
+            href: 'https://rest.messagebird.com/contacts/first-id/groups'
+          },
+          messages: {
+            totalCount: 0,
+            href: 'https://rest.messagebird.com/contacts/first-id/messages'
+          },
+          createdDatetime: '2018-07-13T10:34:08+00:00',
+          updatedDatetime: '2018-07-13T10:34:08+00:00'
+        },
+        {
+          id: 'second-id',
+          href: 'https://rest.messagebird.com/contacts/second-id',
+          msisdn: 49612345678,
+          firstName: 'Hello',
+          lastName: 'World',
+          customDetails: {
+            custom1: null,
+            custom2: null,
+            custom3: null,
+            custom4: null
+          },
+          groups: {
+            totalCount: 0,
+            href: 'https://rest.messagebird.com/contacts/second-id/groups'
+          },
+          messages: {
+            totalCount: 0,
+            href: 'https://rest.messagebird.com/contacts/second-id/messages'
+          },
+          createdDatetime: '2018-07-13T10:33:52+00:00',
+          updatedDatetime: null
+        }
+      ]
+    }
+    );
+
+  messagebird.contacts.list(10, 20, function (err, data) {
+    doTest(err, 'contacts.list', [
+      ['.offset', data.offset === 20],
+      ['.links.first', data.links.first === 'https://rest.messagebird.com/contacts?offset=0'],
+      ['.items[0].msisdn', data.items[0].msisdn === 31612345678],
+      ['.items[1].messages.href', data.items[1].messages.href === 'https://rest.messagebird.com/contacts/second-id/messages']
+    ]);
+  });
+});
+
+queue.push(function () {
+  nock('https://rest.messagebird.com')
+    .get('/contacts')
+    .reply(200, {});
+
+  messagebird.contacts.list(function (err, data) {
+    doTest(err, 'contacts.list.withoutpagination', []);
+  });
 });
 
 // Start the tests

--- a/lib/test.js
+++ b/lib/test.js
@@ -460,10 +460,14 @@ queue.push(function () {
 
 queue.push(function () {
   nock('https://rest.messagebird.com')
-    .patch('/contacts/contact-id', '{"name":"new-name"}')
+    .patch('/contacts/contact-id', '{"firstName":"new-name"}')
     .reply(200, {});
 
-  messagebird.contacts.update('contact-id', 'new-name', function (err, data) {
+  var params = {
+    firstName: 'new-name'
+  };
+
+  messagebird.contacts.update('contact-id', params, function (err, data) {
     doTest(err, 'contacts.update', []);
   });
 });

--- a/lib/test.js
+++ b/lib/test.js
@@ -470,6 +470,102 @@ queue.push(function () {
 
 queue.push(function () {
   nock('https://rest.messagebird.com')
+    .get('/contacts/contact-id/groups')
+    .query({
+      limit: 20,
+      offset: 0
+    })
+    .reply(200, {
+      offset: 0,
+      limit: 20,
+      count: 1,
+      totalCount: 1,
+      links: {
+        first: 'https://rest.messagebird.com/contacts/contact-id/groups?offset=0',
+        previous: null,
+        next: null,
+        last: 'https://rest.messagebird.com/contacts/contact-id/groups?offset=0'
+      },
+      items: [
+        {
+          id: 'group-id',
+          href: 'https://rest.messagebird.com/groups/group-id',
+          name: 'SomeGroup',
+          contacts: {
+            totalCount: 1,
+            href: 'https://rest.messagebird.com/groups/group-id/contacts'
+          },
+          createdDatetime: '2018-08-06T08:34:51+00:00',
+          updatedDatetime: '2018-08-21T14:17:39+00:00'
+        }
+      ]
+    });
+
+  messagebird.contacts.listGroups('contact-id', 20, 0, function (err, data) {
+    doTest(err, 'contacts.listGroups', [
+      ['.totalCount', data.totalCount === 1],
+      ['.items[0].id', data.items[0].id === 'group-id']
+    ]);
+  });
+});
+
+queue.push(function () {
+  nock('https://rest.messagebird.com')
+    .get('/contacts/contact-id/messages')
+    .reply(200, {
+      offset: 0,
+      limit: 20,
+      count: 1,
+      totalCount: 1,
+      links: {
+        first: 'https://rest.messagebird.com/messages/?offset=0',
+        previous: null,
+        next: null,
+        last: 'https://rest.messagebird.com/messages/?offset=0'
+      },
+      items: [
+        {
+          id: 'message-id',
+          href: 'https://rest.messagebird.com/messages/message-id',
+          direction: 'mo',
+          type: 'sms',
+          originator: 'MBird',
+          body: 'Profile',
+          reference: 'MyReference',
+          validity: null,
+          gateway: 0,
+          typeDetails: {},
+          datacoding: 'plain',
+          mclass: 1,
+          scheduledDatetime: null,
+          createdDatetime: '2018-08-31T14:24:22+00:00',
+          recipients: {
+            totalCount: 1,
+            totalSentCount: 1,
+            totalDeliveredCount: 1,
+            totalDeliveryFailedCount: 0,
+            items: [
+              {
+                recipient: 31612345678,
+                originator: null,
+                status: 'delivered',
+                statusDatetime: null
+              }
+            ]
+          }
+        }
+      ]
+    });
+
+  messagebird.contacts.listMessages('contact-id', function (err, data) {
+    doTest(err, 'contacts.listMessages', [
+      ['.items[0].reference', data.items[0].reference === 'MyReference']
+    ]);
+  });
+});
+
+queue.push(function () {
+  nock('https://rest.messagebird.com')
     .delete('/contacts/contact-id')
     .reply(204, '');
 
@@ -753,6 +849,78 @@ queue.push(function () {
 
   messagebird.groups.addContacts('group-id', ['first-id', 'second-id'], function (err) {
     expectError(err, 'groups.addContects.witherror');
+  });
+});
+
+queue.push(function () {
+  nock('https://rest.messagebird.com')
+    .get('/groups/group-id/contacts')
+    .reply(200, {
+      offset: 20,
+      limit: 10,
+      count: 2,
+      totalCount: 22,
+      links: {
+        first: 'https://rest.messagebird.com/contacts?offset=0',
+        previous: null,
+        next: null,
+        last: 'https://rest.messagebird.com/contacts?offset=0'
+      },
+      items: [
+        {
+          id: 'first-id',
+          href: 'https://rest.messagebird.com/contacts/first-id',
+          msisdn: 31612345678,
+          firstName: 'Foo',
+          lastName: 'Bar',
+          customDetails: {
+            custom1: null,
+            custom2: null,
+            custom3: null,
+            custom4: null
+          },
+          groups: {
+            totalCount: 0,
+            href: 'https://rest.messagebird.com/contacts/first-id/groups'
+          },
+          messages: {
+            totalCount: 0,
+            href: 'https://rest.messagebird.com/contacts/first-id/messages'
+          },
+          createdDatetime: '2018-07-13T10:34:08+00:00',
+          updatedDatetime: '2018-07-13T10:34:08+00:00'
+        },
+        {
+          id: 'second-id',
+          href: 'https://rest.messagebird.com/contacts/second-id',
+          msisdn: 49612345678,
+          firstName: 'Hello',
+          lastName: 'World',
+          customDetails: {
+            custom1: null,
+            custom2: null,
+            custom3: null,
+            custom4: null
+          },
+          groups: {
+            totalCount: 0,
+            href: 'https://rest.messagebird.com/contacts/second-id/groups'
+          },
+          messages: {
+            totalCount: 0,
+            href: 'https://rest.messagebird.com/contacts/second-id/messages'
+          },
+          createdDatetime: '2018-07-13T10:33:52+00:00',
+          updatedDatetime: null
+        }
+      ]
+    });
+
+  messagebird.groups.listContacts('group-id', function (err, data) {
+    doTest(err, 'groups.listContacts', [
+      ['.items[0].msisdn', data.items[0].msisdn === 31612345678],
+      ['.items[1].id', data.items[1].id === 'second-id']
+    ]);
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -29,5 +29,7 @@
   "license": "BSD-2-Clause",
   "homepage": "https://github.com/messagebird/messagebird-nodejs",
   "dependencies": {},
-  "devDependencies": {}
+  "devDependencies": {
+    "nock": "^9.6.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   "homepage": "https://github.com/messagebird/messagebird-nodejs",
   "dependencies": {},
   "devDependencies": {
-    "nock": "^9.6.1"
+    "nock": "^8.0.0"
   }
 }


### PR DESCRIPTION
This PR adds support for [contacts](https://developers.messagebird.com/docs/contacts) and [groups](https://developers.messagebird.com/docs/groups). I decided to do this on a single branch because of their similarity and them both relying on the introduction of Nock for mocking requests.