### PR TITLE
httpRequest fix no params call

### DIFF
--- a/lib/messagebird.js
+++ b/lib/messagebird.js
@@ -43,9 +43,9 @@ module.exports = function (accessKey, timeout) {
     var body = null;
     var request;
 
-    if (typeof params === 'function') {
-      callback = params;
-      params = null;
+    if (typeof requestParams === 'function') {
+      callback = requestParams;
+      requestParams = null;
     }
 
     /**


### PR DESCRIPTION
Sorry I didn't noticed this during my original add-contestations pull request https://github.com/messagebird/messagebird-nodejs/pull/25!