### PR TITLE
Use relative imports for verify and voice_message types

### DIFF
--- a/types/verify.d.ts
+++ b/types/verify.d.ts
@@ -1,6 +1,6 @@
-import { msisdn, datetime } from 'general';
-import { dataCoding } from 'messages';
-import { languages } from 'voice_messages';
+import { msisdn, datetime } from './general';
+import { dataCoding } from './messages';
+import { languages } from './voice_messages';
 
 export interface Verify {
   /** A unique random ID which is created on the MessageBird platform and is returned upon creation of the object */

--- a/types/voice_messages.d.ts
+++ b/types/voice_messages.d.ts
@@ -1,4 +1,4 @@
-import { datetime, msisdn } from 'general';
+import { datetime, msisdn } from './general';
 
 export type languages =
   | 'cy-gb'


### PR DESCRIPTION
There was an issue with the `verify` and `voice_messages` typings not using relative import paths causing the typings to break.

https://github.com/messagebird/messagebird-nodejs/pull/27#issuecomment-468189267


@yss14 thank you for bringing this to our attention! 😌 