### PR TITLE
Fixed WhatsApp HSM languages

### DIFF
--- a/types/conversations.d.ts
+++ b/types/conversations.d.ts
@@ -1,6 +1,72 @@
 import { datetime } from './general';
-import { languages } from './voice_messages';
 import { Contact } from './contact';
+
+export type hsmLanguages =
+  | 'af'
+  | 'sq'
+  | 'ar'
+  | 'az'
+  | 'bn'
+  | 'bg'
+  | 'ca'
+  | 'zh_CN'
+  | 'zh_HK'
+  | 'zh_TW'
+  | 'hr'
+  | 'cs'
+  | 'da'
+  | 'nl'
+  | 'en'
+  | 'en_GB'
+  | 'es_LA'
+  | 'et'
+  | 'fil'
+  | 'fi'
+  | 'fr'
+  | 'de'
+  | 'el'
+  | 'gu'
+  | 'he'
+  | 'hi'
+  | 'hu'
+  | 'id'
+  | 'ga'
+  | 'it'
+  | 'ja'
+  | 'kn'
+  | 'kk'
+  | 'ko'
+  | 'lo'
+  | 'lv'
+  | 'lt'
+  | 'mk'
+  | 'ms'
+  | 'mr'
+  | 'nb'
+  | 'fa'
+  | 'pl'
+  | 'pt_BR'
+  | 'pt_PT'
+  | 'pa'
+  | 'ro'
+  | 'ru'
+  | 'sr'
+  | 'sk'
+  | 'sl'
+  | 'es'
+  | 'es_AR'
+  | 'es_ES'
+  | 'es_MX'
+  | 'sw'
+  | 'sv'
+  | 'ta'
+  | 'te'
+  | 'th'
+  | 'tr'
+  | 'uk'
+  | 'ur'
+  | 'uz'
+  | 'vi';
 
 export interface StartConversationParameter {
   /** The type of the message content. */
@@ -279,7 +345,7 @@ export interface HSMLanguage {
    */
   policy: 'fallback' | 'deterministic';
   /** The code of the language or locale to use, accepts both language and language_locale formats (e.g., en or en_US). */
-  code: languages;
+  code: hsmLanguages;
 }
 
 export type HSMLocalizableParameters =


### PR DESCRIPTION
I had a problem trying to send a WhatsApp Message Template (with `HSMContent`). 

Using TypeScript, when I tried to send a message I could not write my corresponding `es` language `code`, my only alternative was to use `es-es` (which did not correspond to the language of my template). I tried it anyway and the message was rejected, it was not sent.

So, I modified the list of supported languages specifically for the `HSMLanguage` class

You can check the [complete list of codes here](https://developers.facebook.com/docs/whatsapp/api/messages/message-templates#language)