### PR TITLE
ExpressMiddlewareVerify stop the callback chain

### DIFF
--- a/lib/webhook-signature-jwt.js
+++ b/lib/webhook-signature-jwt.js
@@ -126,7 +126,7 @@ function ExpressMiddlewareVerify(secret, opts = DefaultVerifyOptions) {
           body = req.body;
         }
 
-        return verify(url, body, jwt, sk, opts);
+        verify(url, body, jwt, sk, opts);
       }).then(next).catch(err => next(err));
   };
 }


### PR DESCRIPTION
ExpressMiddlewareVerify inner function shouldn't return the result of verify as it stop the callback chain.